### PR TITLE
Fix intellisense options being disabled when there is no active object in the current scene

### DIFF
--- a/intellisense_addon.py
+++ b/intellisense_addon.py
@@ -63,10 +63,6 @@ class TEXT_OT_intellisense_options(bpy.types.Operator):
 
     text: bpy.props.StringProperty()
 
-    @classmethod
-    def poll(cls, context):
-        return context.active_object is not None
-
     def execute(self, context):
         sc = context.space_data
         text = sc.text


### PR DESCRIPTION
None of the options in the intellisense menu that appears when pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd> can be selected unless there is an active object in the current scene, which obviously shouldn't be necessary. Removing the poll function for the operator solves this. 

The other poll function in `text.intellisense`, which had already been commented out, can also safely be removed (but I left that to you).